### PR TITLE
Updated updateCode dispatch.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ const Store = {
   },
   actions: {
     updateCode: function (context, payload) {
-      context.commit('code', payload.code)
+      context.commit('code', payload)
     }
   },
   // TODO: Enable strict for development?


### PR DESCRIPTION
No value to use a {} payload instead of a simple 'A.method'.