### PR TITLE
Add production environment variable to vite.config.lib.js

### DIFF
--- a/vite.config.lib.js
+++ b/vite.config.lib.js
@@ -47,6 +47,9 @@ export default defineConfig({
     }),
     cssInjectedByJsPlugin(),
   ],
+  define: {
+    'process.env.NODE_ENV': '"production"'
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
This PR fixes the issue raised in [this Mermaid PR](https://github.com/mermaid-js/mermaid/pull/4334).
The issue is caused by the missing `process.env.NODE_ENV` environment variable. This fix will add the missing variable when the bundle is being built.

